### PR TITLE
use walkdir to find pam_motd.so

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,21 @@
+name: nightly
+on:
+  schedule:
+    - cron: '04 05 * * *'
+
+jobs:
+  deny:
+    name: cargo deny --all-features check
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: moonrepo/setup-rust@b8edcc56aab474d90c7cf0bb8beeaf8334c15e9f
+        with:
+          channel: '1.74.0'
+          bins: cargo-deny
+            # TODO: use rust to make the overlay shim so we don't need this
+      - run: sudo apt-get install libpam0g-dev
+      - run: cargo deny --all-features check
+
+  postsubmit:
+    uses: ./.github/workflows/presubmit.yml

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -1,0 +1,67 @@
+name: presubmit
+on: [push, pull_request, workflow_call, workflow_dispatch]
+
+jobs:
+  test:
+    name: cargo test --all-features
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: moonrepo/setup-rust@b8edcc56aab474d90c7cf0bb8beeaf8334c15e9f
+        with:
+          channel: '1.74.0'
+            # TODO: use rust to make the overlay shim so we don't need this
+      - run: sudo apt-get install libpam0g-dev
+      - run: cargo test --all-features
+
+        # TODO: miri has trouble with some of our IO, I think the re-exec causes issues
+        # miri:
+        #   name: cargo +nightly miri test
+        #   runs-on: ubuntu-22.04
+        #   steps:
+        #     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        #     - uses: moonrepo/setup-rust@b8edcc56aab474d90c7cf0bb8beeaf8334c15e9f
+        #       with:
+        #         components: miri
+        #         channel: nightly
+        #           # TODO: use rust to make the overlay shim so we don't need this
+        #     - run: sudo apt-get install libpam0g-dev
+        #     - run: MIRIFLAGS="-Zmiri-disable-isolation" cargo +nightly miri test
+
+  rustfmt:
+    name: cargo +nightly fmt -- --check
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: moonrepo/setup-rust@b8edcc56aab474d90c7cf0bb8beeaf8334c15e9f
+        with:
+          components: rustfmt
+          channel: nightly
+      - run: cargo +nightly fmt -- --check
+
+  cranky:
+    name: cargo +nightly cranky --all-targets -- -D warnings
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: moonrepo/setup-rust@v1
+        with:
+          components: clippy
+          bins: cargo-cranky@0.3.0
+          channel: nightly
+            # TODO: use rust to make the overlay shim so we don't need this
+      - run: sudo apt-get install libpam0g-dev
+      - run: cargo +nightly cranky --all-targets -- -D warnings
+
+  deny:
+    name: cargo deny --all-features check licenses
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: moonrepo/setup-rust@b8edcc56aab474d90c7cf0bb8beeaf8334c15e9f
+        with:
+          channel: '1.74.0'
+          bins: cargo-deny
+            # TODO: use rust to make the overlay shim so we don't need this
+      - run: sudo apt-get install libpam0g-dev
+      - run: cargo deny --all-features check licenses

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tempfile",
+ "walkdir",
  "which",
 ]
 
@@ -172,6 +173,15 @@ name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "serde"
@@ -234,6 +244,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "which"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +281,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,20 @@
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+vulnerability = "deny"
+unmaintained = "deny"
+yanked = "deny"
+notice = "deny"
+ignore = [
+]
+
+[licenses]
+unlicensed = "deny"
+allow = [
+    "Apache-2.0",
+    "MIT",
+    "Unicode-DFS-2016",
+]
+copyleft = "deny"
+default = "deny"
+confidence-threshold = 1.0

--- a/dump-motd/src/main.rs
+++ b/dump-motd/src/main.rs
@@ -1,11 +1,16 @@
 fn main() {
     motd::handle_reexec();
 
-    match motd::value(
-        motd::PamMotdResolutionStrategy::Auto,
-        motd::ArgResolutionStrategy::Auto,
-    ) {
-        Ok(v) => print!("{}", v),
-        Err(e) => eprintln!("Error getting motd: {}", e),
+    if let Err(e) = run() {
+        eprintln!("Error getting motd: {}", e);
     }
+}
+
+fn run() -> Result<(), motd::Error> {
+    let motd_resolver = motd::Resolver::new(motd::PamMotdResolutionStrategy::Auto)?;
+    print!(
+        "{}",
+        motd_resolver.value(motd::ArgResolutionStrategy::Auto)?
+    );
+    Ok(())
 }

--- a/motd/Cargo.toml
+++ b/motd/Cargo.toml
@@ -23,7 +23,8 @@ tempfile = "3"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
-dlopen2 = "0.7"
+dlopen2 = "0.7.0"
+walkdir = "2.5.0"
 
 [build-dependencies]
 which = "6"


### PR DESCRIPTION
This patch switches to using the walkdir crate to find pam_motd.so, and changes the API so that we cache the result. Taken together these changes go a long way to mitigating the fact that we need to root around in /usr/lib to find pam_motd.so. walkdir is much faster than the naive code that I wrote as part of my first wack at things and caching the result means that a user does not need to pay for the walk each time (they technically could have cached with the old API, but it would have been pretty gross, better to do it for them).