### PR TITLE
motd: cut v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "motd"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dlopen2",
  "lazy_static",

--- a/README.md
+++ b/README.md
@@ -13,3 +13,20 @@ systems you can do so with
 ```
 sudo apt-get install libpam0g-dev
 ```
+
+## Features
+
+There are two modes of operation for the `motd` crate. By default, it
+will load and call into the `pam_motd.so` file used by the pam stack,
+but you can instead use a pure rust reimplementation of the logic found
+in `pam_motd.so` if you want. The downside of the pure rust implementation
+is that it no longer uses the same source-of-truth logic to resolve the
+motd, though this is likely not a huge deal because `pam_motd` is fairly
+stable. The pure rust implementation has the advantages that it uses zero
+unsafe code, does not require a (sometimes slow) directory walk to
+locate `pam_motd.so` the first time it is run, and requires many fewer
+dependencies.
+
+The feature for calling `pam_motd.so` directly is `socall`, and it is
+enabled by default. To use the pure rust implementation, disable
+default features. This will change the signature of a few functions.

--- a/motd/Cargo.toml
+++ b/motd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motd"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 repository = "https://github.com/shell-pool/motd"
 authors = ["Ethan Pailes <pailes@google.com>"]
@@ -9,7 +9,8 @@ description = '''
 motd interrogates pam_motd.so in order to determine the current
 message of the day. It only works on linux and it is a component of
 the shpool tool, though you can also use the dump-motd wrapper CLI
-tool directly.
+tool directly. Through feature selection, you can also use a
+pure rust impl with no dlopen shennigans.
 '''
 license = "Apache-2.0"
 keywords = ["motd", "ssh", "terminal", "shell"]


### PR DESCRIPTION
This patch cuts a new version for the motd
crate. The dump-motd wrapper binary remains
unchanged.