### PR TITLE
suppress missing_transmute_annotations clippy

### DIFF
--- a/Cranky.toml
+++ b/Cranky.toml
@@ -1,0 +1,5 @@
+allow = [
+    "unknown_lints",
+    "clippy::needless_doctest_main",
+    "clippy::missing_transmute_annotations",
+]

--- a/motd/src/lib.rs
+++ b/motd/src/lib.rs
@@ -58,8 +58,6 @@ let motd_msg = motd_resolver.value(motd::ArgResolutionStrategy::Auto)?;
 ```
 */
 
-#![allow(clippy::needless_doctest_main)]
-
 use std::{
     fmt::Debug,
     fs, io,


### PR DESCRIPTION
Rust has type inference for a reason. This is a bad lint.

The nightly builds are complaining
https://github.com/shell-pool/motd/actions/runs/8641814201/job/23691943646