### PR TITLE
motd: cut version 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "dump-motd"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "motd",
 ]
@@ -107,7 +107,7 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "motd"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "dlopen2",
  "lazy_static",

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ crate.
 
 ## Dependencies
 
-You must install libpam headers to build this crate. On debian based
+If using the `socall` feature (which is on by default), you must
+install libpam headers to build this crate. On debian based
 systems you can do so with
 
 ```

--- a/dump-motd/Cargo.toml
+++ b/dump-motd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dump-motd"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 repository = "https://github.com/shell-pool/motd"
 authors = ["Ethan Pailes <pailes@google.com>"]
@@ -15,4 +15,4 @@ license = "Apache-2.0"
 keywords = ["motd", "ssh", "terminal", "shell"]
 
 [dependencies]
-motd = { version = "0.2.0", path = "../motd" }
+motd = { version = "0.2", path = "../motd" }

--- a/motd/Cargo.toml
+++ b/motd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motd"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 repository = "https://github.com/shell-pool/motd"
 authors = ["Ethan Pailes <pailes@google.com>"]


### PR DESCRIPTION
This patch cuts a new version of the motd
crate (0.2.2) and of the dump-motd tool (0.2.1).

With this change, we no longer need libpam to
build in non-socall mode.